### PR TITLE
Add introductietarief information to treatment section

### DIFF
--- a/_data/behandelingen.yml
+++ b/_data/behandelingen.yml
@@ -1,5 +1,6 @@
 - naam: Lotus Moment sessie
   duur: 90 min
+  tarief: "Introductietarief: €35 per sessie (dit tarief wordt in de toekomst verhoogd)."
   omschrijving: >
     Eén behandeling met drie fases zodat je volledig kunt landen: een zachte intake, een intuïtieve massage en integratie.
   resultaat: Je stapt helder, gegrond en met een ontspannen zenuwstelsel weer naar buiten.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -38,6 +38,9 @@ layout: default
       <article class="treatment-card">
         <span class="pill">{{ treatment.duur }}</span>
         <h3>{{ treatment.naam }}</h3>
+        {% if treatment.tarief %}
+        <p class="treatment-price"><strong>Tarief:</strong> {{ treatment.tarief }}</p>
+        {% endif %}
         <p>{{ treatment.omschrijving }}</p>
         {% if treatment.resultaat %}
         <p><strong>Resultaat:</strong> {{ treatment.resultaat }}</p>


### PR DESCRIPTION
## Summary
- documenteer het introductietarief van €35 voor de Lotus Moment sessie inclusief de melding dat dit in de toekomst stijgt
- toon het tarief in de behandelkaart op de homepage zodat bezoekers direct het actuele bedrag zien

## Testing
- niet uitgevoerd (Bundler 1.17.2 is niet compatibel met de Ruby-versie in de container)

------
https://chatgpt.com/codex/tasks/task_e_68e56956f6d88325b11fb05e4fdea745